### PR TITLE
Ember 1.13 - Mark style string as htmlSafe to stop inline style modification deprecation warning

### DIFF
--- a/addon/components/initials-avatar.js
+++ b/addon/components/initials-avatar.js
@@ -29,7 +29,8 @@ export default Ember.Component.extend({
    */
   style: function() {
     if (this.get('hasImage')) {
-      return 'background-image: url(' + Ember.Handlebars.Utils.escapeExpression(this.get('image')) + '); background-size: cover';
+      var escapedUrl = Ember.Handlebars.Utils.escapeExpression(this.get('image'));
+      return Ember.String.htmlSafe(`background-image: url(${escapedUrl}); background-size: cover`);
     }
   }.property('hasImage'),
 


### PR DESCRIPTION
This work is done on top of the work in did in #9. I tried to keep them isolated though.

This is to resolve the deprecation warning I see since upgrading to 1.13: 

http://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes