### PR TITLE
htmlSafe style attributeBindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/addon/components/initials-avatar.js
+++ b/addon/components/initials-avatar.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+const { computed, Handlebars, isPresent, Component } = Ember;
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: [':initialsAvatar', 'avatarColor'],
   attributeBindings: ['style'],
 
@@ -13,27 +14,36 @@ export default Ember.Component.extend({
 
   hasImage: Ember.computed.notEmpty('image'),
 
-  initials: Ember.computed('firstName', 'lastName', 'company', function() {
-    var first = this.initial(this.get('firstName')),
-      last = this.initial(this.get('lastName')),
-      company = this.initial(this.get('company'));
+  initials: computed('firstName', 'lastName', 'company', function() {
+    const first = this.initial(this.get('firstName'));
+    const last = this.initial(this.get('lastName'));
+    const company = this.initial(this.get('company'));
+
     return (first + last) || company;
   }),
 
-  initial: function(word) {
-    return Ember.isPresent(word) ? word[0] : "";
+  initial(word) {
+    return isPresent(word) ? word[0] : "";
   },
 
   /**
    * Display the image using a background-image inline style
    */
-  style: Ember.computed('hasImage', function() {
+  style: computed('hasImage', function(){
+    // Ember complains about htmlSafe strings when a bound style method returns
+    // nothing. Returning an empty string turns off the warning but leaves an
+    // empty style attribute on the div.
+    let style = '';
+
     if (this.get('hasImage')) {
-      return 'background-image: url(' + Ember.Handlebars.Utils.escapeExpression(this.get('image')) + '); background-size: cover';
+      var escapedUrl = Handlebars.Utils.escapeExpression(this.get('image'));
+      style = `background-image: url(${escapedUrl}); background-size: cover`;
     }
+
+    return Ember.String.htmlSafe(style);
   }),
 
-  avatarColor: Ember.computed('maxColors', 'colorIndex', function() {
+  avatarColor: computed('maxColors', 'colorIndex', function() {
     var index = this.get('colorIndex');
     index = (index - 1) % this.get('maxColorIndex') + 1;
     return 'avatarColor-' + index;

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,24 +12,24 @@ module.exports = {
       resolutions: {
         'ember': 'release'
       }
-    },
-    {
-      name: 'ember-beta',
-      dependencies: {
-        'ember': 'components/ember#beta'
-      },
-      resolutions: {
-        'ember': 'beta'
-      }
-    },
-    {
-      name: 'ember-canary',
-      dependencies: {
-        'ember': 'components/ember#canary'
-      },
-      resolutions: {
-        'ember': 'canary'
-      }
     }
+    // {
+    //   name: 'ember-beta',
+    //   dependencies: {
+    //     'ember': 'components/ember#beta'
+    //   },
+    //   resolutions: {
+    //     'ember': 'beta'
+    //   }
+    // },
+    // {
+    //   name: 'ember-canary',
+    //   dependencies: {
+    //     'ember': 'components/ember#canary'
+    //   },
+    //   resolutions: {
+    //     'ember': 'canary'
+    //   }
+    // }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "author": "freshbooks",
   "license": "MIT",
+  "dependencies": {
+    "ember-cli-babel": "^5.1.3"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "0.2.7",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   "author": "freshbooks",
   "license": "MIT",
   "dependencies": {
-    "ember-cli-babel": "^5.1.3"
+    "ember-cli-babel": "^5.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "0.2.7",
+    "ember-cli": "1.13.7",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
@@ -41,9 +41,6 @@
   "keywords": [
     "ember-addon"
   ],
-  "dependencies": {
-    "ember-cli-babel": "^5.0.0"
-  },
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }

--- a/tests/unit/components/initials-avatar-test.js
+++ b/tests/unit/components/initials-avatar-test.js
@@ -82,7 +82,7 @@ test('displays initials if no image is given', function(assert) {
 
   var $component = this.append();
 
-  assert.equal($component.attr('style'), undefined);
+  assert.equal($component.attr('style'), '');
   assert.equal($component.text().trim(), 'BO');
 });
 


### PR DESCRIPTION
For some reason, the warning about binding style attributes literally requires you to return something wrapped in `htmlSafe()`. Returning nothing at all doesn't count. That's probably a bug in ember but for now, returning an empty string works. 
