### PR TITLE
use encoded image urls

### DIFF
--- a/addon/components/initials-avatar.js
+++ b/addon/components/initials-avatar.js
@@ -36,7 +36,7 @@ export default Component.extend({
    */
   style: computed('hasImage', 'color', function() {
     if (this.get('hasImage')) {
-      return htmlSafe(`background-image: url(${this.get('image')}); background-size: cover`);
+      return htmlSafe(`background-image: url("${encodeURI(this.get('image'))}"); background-size: cover`);
     } else if (this.get('color')) {
       return htmlSafe(`background-color: ${this.get('color')};`);
     }

--- a/tests/integration/components/initials-avatar-test.js
+++ b/tests/integration/components/initials-avatar-test.js
@@ -33,7 +33,7 @@ module('Integration | Component | initials avatar', function(hooks) {
 
     assert.dom('#initials-avatar').hasAttribute(
       'style',
-      'background-image: url(http://example.com/potus.jpg); background-size: cover'
+      'background-image: url("http://example.com/potus.jpg"); background-size: cover'
     );
     assert.dom('#initials-avatar').hasText('');
   });
@@ -69,7 +69,24 @@ module('Integration | Component | initials avatar', function(hooks) {
 
     assert.dom('#initials-avatar').hasAttribute(
       'style',
-      'background-image: url(http://example.com/potus.jpg); background-size: cover'
+      'background-image: url("http://example.com/potus.jpg"); background-size: cover'
+    );
+    assert.dom('#initials-avatar').hasText('');
+  });
+
+  test('uses encoded image urls', async function(assert) {
+    assert.expect(2);
+
+    await render(hbs`
+      {{initials-avatar
+        id="initials-avatar"
+        image="http://example.com/potus.jpg?param=\\"asdssadad\\""
+      }}
+    `);
+
+    assert.dom('#initials-avatar').hasAttribute(
+      'style',
+      'background-image: url("http://example.com/potus.jpg?param=%22asdssadad%22"); background-size: cover'
     );
     assert.dom('#initials-avatar').hasText('');
   });


### PR DESCRIPTION
Sometimes we might need to use weirder image urls such as `https://mydomain.com/image.jpg?param="value"`.
These would fail as we're not encoding the url before using it as a css value.

Also added a test for this case.